### PR TITLE
"Add searchMovie endpoint and genres id -> name convertor"

### DIFF
--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -4,7 +4,8 @@ import express, { type Express, type Request, type Response } from "express";
 // import config from "./utils/config.js";
 // import connectDB from "./utils/mongo.js";
 
-import userRoutes from "./routes/userRoutes";
+// import userRoutes from "./routes/userRoutes";
+import searchRoutes from "./routes/searchRoutes";
 
 // import errorHandler from "./middleware/errorHandler.js";
 // import { requestLogger, unknownEndpoint } from "./utils/middleware.js";
@@ -20,11 +21,9 @@ app.get("/api", (req: Request, res: Response) => {
     res.send("Hello World!");    
 });
 
-app.use("/api/v1/users", userRoutes);    
+// app.use("/api/v1/users", userRoutes);    
+app.use("/api/v1/search", searchRoutes);    
 
-app.use("/api/v1/omdb", (req: Request, res: Response) => {
-    res.send("Hello OMDB!");    
-});
 app.use("/api/v1/buff", (req: Request, res: Response) => {
     res.send("Hello MovAI!");    
 });

--- a/server/src/controllers/search/getSearchMovies.ts
+++ b/server/src/controllers/search/getSearchMovies.ts
@@ -1,0 +1,56 @@
+import type { Request, Response, NextFunction } from 'express';
+import { tmdbSearchAPI } from '../../utils/axiosInstances';
+import { TMDB_IMAGE_API_THAMNAIL } from '../../utils/config';
+import genresList from '../../utils/genresList';
+
+const getSearchMovies = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    const { query, page } = req.query;
+    const fetchURL = `/movie?query=${query}&page=${page}`;
+
+    try {
+        const { data } = await tmdbSearchAPI.get(fetchURL);
+        // res.status(200).json(data);
+        res.status(200).json(shapeMovieList(data));
+    } catch (error) {
+        next(error);
+    }
+};
+
+export default getSearchMovies;
+
+// https://api.themoviedb.org/3/search/movie?api_key=${TMDP_API_KEY}&language=en-US&query=${query}&page=${page}&include_adult=false
+
+function shapeMovieList(movies: MovieList) {
+    return {
+    page: movies.page,
+    total_pages: movies.total_pages,
+    total_results: movies.total_results,
+    results: movies.results.map((movie: Movie) => ({
+					id: movie.id,
+					genres_list: movie.genre_ids.map((id) => genresList[id]),
+					title: movie.title,
+                    original_title: movie.original_title,
+                    overview: movie.overview,
+					release_date: movie.release_date,
+					poster_path: `${TMDB_IMAGE_API_THAMNAIL}${movie.poster_path}`,
+				}))
+    }
+};
+
+interface MovieList {
+    page: number;
+    total_pages: number;
+    total_results: number;
+    results: Movie[];
+
+}
+
+interface Movie {
+    id: number;
+    genre_ids: number[];
+    title: string;
+    original_title: string;
+    overview: string;
+    release_date: string;
+    poster_path: string;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import app from './app';
-import config from './utils/config';
+import { PORT } from './utils/config';
 import logger from './utils/logger';
 
-app.listen(config.PORT, () => {
-	logger.info(`Server running on port ${config.PORT}`);
+app.listen(PORT, () => {
+	logger.info(`Server running on port ${PORT}`);
 });

--- a/server/src/routes/searchRoutes.ts
+++ b/server/src/routes/searchRoutes.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+import getSearchMovies from "../controllers/search/getSearchMovies";
+
+const searchRoutes = express.Router();
+
+searchRoutes.get("/movies", getSearchMovies);
+
+export default searchRoutes;

--- a/server/src/utils/axiosInstances.ts
+++ b/server/src/utils/axiosInstances.ts
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+import { TMDB_AUTH_TOKEN, TMDB_URL } from './config';
+
+const tmdbSearchAPI = axios.create({
+    baseURL: `${TMDB_URL}/search`,
+    headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${TMDB_AUTH_TOKEN}`
+    },
+});
+
+export { tmdbSearchAPI };

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -1,4 +1,9 @@
 const PORT = process.env.PORT || 3001;
+const TMDB_URL = process.env.TMDB_URL;
+const TMDB_AUTH_TOKEN = process.env.TMDB_AUTH_TOKEN;
+const TMDB_IMG_URL = process.env.TMDB_IMG_URL;
+const TMDB_API_KEY = process.env.TMDB_API_KEY;
+
 // const MONGODB_URI = process.env.MONGODB_URI;
 // const JWT_SECRET = process.env.JWT_SECRET;
 
@@ -7,4 +12,4 @@ const PORT = process.env.PORT || 3001;
 // };
 
 // export default { PORT, MONGODB_URI, JWT_SECRET, corsOptions };
-export default { PORT };
+export { PORT, TMDB_URL, TMDB_AUTH_TOKEN, TMDB_IMG_URL, TMDB_API_KEY };

--- a/server/src/utils/config.ts
+++ b/server/src/utils/config.ts
@@ -1,15 +1,17 @@
 const PORT = process.env.PORT || 3001;
-const TMDB_URL = process.env.TMDB_URL;
+
 const TMDB_AUTH_TOKEN = process.env.TMDB_AUTH_TOKEN;
-const TMDB_IMG_URL = process.env.TMDB_IMG_URL;
 const TMDB_API_KEY = process.env.TMDB_API_KEY;
+const TMDB_URL = process.env.TMDB_API;
+const TMDB_IMAGE_API = process.env.TMDB_IMAGE_API;
+const TMDB_IMAGE_API_THAMNAIL = `${TMDB_IMAGE_API}92`;
 
 // const MONGODB_URI = process.env.MONGODB_URI;
 // const JWT_SECRET = process.env.JWT_SECRET;
 
 // const corsOptions = {
-// 	origin: process.env.ORIGINS.split(", "),
-// };
+    // 	origin: process.env.ORIGINS.split(", "),
+    // };
+    
 
-// export default { PORT, MONGODB_URI, JWT_SECRET, corsOptions };
-export { PORT, TMDB_URL, TMDB_AUTH_TOKEN, TMDB_IMG_URL, TMDB_API_KEY };
+export { PORT, TMDB_URL, TMDB_AUTH_TOKEN, TMDB_IMAGE_API, TMDB_API_KEY, TMDB_IMAGE_API_THAMNAIL };

--- a/server/src/utils/genresList.ts
+++ b/server/src/utils/genresList.ts
@@ -1,0 +1,23 @@
+const genresList: { [key: number]: string } = {
+    28: "Action",
+    12: "Adventure",
+    16: "Animation",
+    35: "Comedy",
+    80: "Crime",
+    99: "Documentary",
+    18: "Drama",
+    10751: "Family",
+    14: "Fantasy",
+    36: "History",
+    27: "Horror",
+    10402: "Music",
+    9648: "Mystery",
+    10749: "Romance",
+    878: "Science Fiction",
+    10770: "TV Movie",
+    53: "Thriller",
+    10752: "War",
+    37: "Western",
+};
+
+export default genresList;


### PR DESCRIPTION
This pull request adds a new endpoint called `searchMovies` to the API. This endpoint allows users to search for movies based on a query and page number. It uses the TMDB API to fetch the search results and returns a formatted response with the movie details, including the genre names instead of genre IDs. Additionally, a `genresList` utility function is added to map genre IDs to their corresponding names.